### PR TITLE
Fix compilation on libtorrent-0.15.4 (and possibly other versions)

### DIFF
--- a/hrktorrent.h
+++ b/hrktorrent.h
@@ -21,6 +21,7 @@
 #include <libtorrent/session.hpp>
 #include <libtorrent/session_settings.hpp>
 #include <libtorrent/ip_filter.hpp>
+#include <libtorrent/error_code.hpp>
 
 #include "version.h"
 #include "core.h"

--- a/ipfilter.cpp
+++ b/ipfilter.cpp
@@ -50,7 +50,7 @@ CIPFilter::AddRule(std::string start, std::string end)
 	try {
 		astart = libtorrent::address::from_string(start);
 		aend = libtorrent::address::from_string(end);
-	} catch(asio::system_error& e) {
+	} catch(libtorrent::error_code& e) {
 		return false; // invalid rule
 	}
 


### PR DESCRIPTION
The only needed change was due to some namespace modifications, rather than using an exception from the asio namespace, the code now uses one from the libtorrent namespace.

Note that some of the functions in use are still depricated in this libtorrent version, so warnings (not errors) about this are emitted on compilation.

(The previous request asked for merging in the incorrect branch, causing me to close it immediately. My apologies for the spam.)
